### PR TITLE
feat: improve static analysis diagnostics

### DIFF
--- a/src/static-analyzer/__tests__/integration.test.ts
+++ b/src/static-analyzer/__tests__/integration.test.ts
@@ -51,7 +51,28 @@ describe('FreeMarker Static Analyzer Integration', () => {
       expect(result2).toBeDefined();
       expect(result2.semanticInfo).toBeDefined();
     });
-  });
+
+      test('reports missing import as diagnostic', () => {
+        const template = '<#import "missing.ftl" as m/>';
+        const result = analyzer.analyze(template, '/project/main.ftl');
+
+        expect(result.diagnostics.some(d => d.code === 'FTL4001')).toBe(true);
+      });
+
+      test('reports undefined variable as diagnostic', () => {
+        const template = '${foo}';
+        const result = analyzer.analyze(template);
+
+        expect(result.diagnostics.some(d => d.code === 'FTL2001')).toBe(true);
+      });
+
+      test('reports syntax error as diagnostic', () => {
+        const template = '${foo';
+        const result = analyzer.analyze(template);
+
+        expect(result.diagnostics.some(d => d.code === 'FTL1005')).toBe(true);
+      });
+    });
 
   describe('Basic robustness', () => {
     test('should handle simple malformed template', () => {

--- a/src/static-analyzer/index.ts
+++ b/src/static-analyzer/index.ts
@@ -1,8 +1,10 @@
 import { FreeMarkerLexer } from './lexer';
-import { FreeMarkerParser } from './parser';
+import { FreeMarkerParser, TemplateNode } from './parser';
 import { SemanticAnalyzer } from './semantic-analyzer';
 import { ErrorReporter } from './error-reporter';
 import { PerformanceProfiler } from './performance-profiler';
+import * as fs from 'fs';
+import * as path from 'path';
 
 export interface AnalysisResult {
   ast: any;
@@ -88,29 +90,53 @@ export class FreeMarkerStaticAnalyzer {
     this.parser = new FreeMarkerParser([]);
   }
 
-  public analyze(template: string, _filePath?: string): AnalysisResult {
-    this.profiler.start();
-    
-    try {
-      // Tokenize
-      this.profiler.startPhase('lexing');
-      const tokens = this.lexer.tokenize(template);
+    public analyze(template: string, filePath?: string): AnalysisResult {
+      this.profiler.start();
+      this.errorReporter.clear();
+
+      try {
+        this.checkBasicSyntax(template);
+        // Tokenize
+        this.profiler.startPhase('lexing');
+        const tokens = this.lexer.tokenize(template);
       this.profiler.endPhase('lexing');
 
       // Parse
-      this.profiler.startPhase('parsing');
-      this.parser = new FreeMarkerParser(tokens);
-      const ast = this.parser.parse();
-      this.profiler.endPhase('parsing');
+        this.profiler.startPhase('parsing');
+        this.parser = new FreeMarkerParser(tokens);
+        let ast: TemplateNode;
+        try {
+          ast = this.parser.parse();
+          this.profiler.endPhase('parsing');
+        } catch (parseError) {
+          this.profiler.endPhase('parsing');
+          const range = ErrorReporter.createRangeFromOffsets(template, 0, template.length);
+          this.errorReporter.addError(`Syntax error: ${parseError}`, range, 'FTL1001');
+          const performance = this.generatePerformanceMetrics();
+          return {
+            ast: null,
+            diagnostics: this.errorReporter.getDiagnostics(),
+            semanticInfo: {
+              variables: new Map(),
+              macros: new Map(),
+              functions: new Map(),
+              includes: [],
+              imports: []
+            },
+            performance
+          };
+        }
 
-      // Semantic analysis
-      this.profiler.startPhase('semanticAnalysis');
-      const semanticInfo = this.semanticAnalyzer.analyze(ast);
-      this.profiler.endPhase('semanticAnalysis');
+        // Semantic analysis
+        this.profiler.startPhase('semanticAnalysis');
+        const semanticInfo = this.semanticAnalyzer.analyze(ast, this.errorReporter);
+        this.profiler.endPhase('semanticAnalysis');
+
+      this.validateDependencies(template, ast, filePath);
 
       // Collect diagnostics
       const diagnostics = this.errorReporter.getDiagnostics();
-      
+
       // Performance metrics
       const performance = this.generatePerformanceMetrics();
 
@@ -125,7 +151,7 @@ export class FreeMarkerStaticAnalyzer {
         start: { line: 1, character: 1, offset: 0 },
         end: { line: 1, character: 1, offset: 0 }
       });
-      
+
       return {
         ast: null,
         diagnostics: this.errorReporter.getDiagnostics(),
@@ -157,6 +183,53 @@ export class FreeMarkerStaticAnalyzer {
 
   public clearDiagnostics(): void {
     this.errorReporter.clear();
+  }
+
+  private checkBasicSyntax(content: string): void {
+    const interpolationRegex = /\$\{/g;
+    let match: RegExpExecArray | null;
+    while ((match = interpolationRegex.exec(content)) !== null) {
+      if (content.indexOf('}', match.index) === -1) {
+        const range = ErrorReporter.createRangeFromOffsets(content, match.index, content.length);
+        this.errorReporter.addError('Unclosed interpolation', range, 'FTL1005');
+      }
+    }
+  }
+
+  private validateDependencies(content: string, ast: TemplateNode, filePath?: string): void {
+    if (!filePath) {
+      return;
+    }
+
+    const baseDir = path.dirname(filePath);
+
+    const checkPath = (p: string, start: number, end: number): void => {
+      const resolved = path.resolve(baseDir, p);
+      if (!fs.existsSync(resolved)) {
+        const range = ErrorReporter.createRangeFromOffsets(content, start, end);
+        this.errorReporter.addError(`File not found: ${p}`, range, 'FTL4001');
+      }
+    };
+
+    if (ast.imports.length > 0) {
+      ast.imports.forEach(imp => checkPath(imp.path, imp.range.start.offset, imp.range.end.offset));
+    } else {
+      const importRegex = /<#import\s+['"]([^'"<>]+)['"]/g;
+      let match: RegExpExecArray | null;
+      while ((match = importRegex.exec(content)) !== null) {
+        checkPath(match[1], match.index, match.index + match[0].length);
+      }
+    }
+
+    if (ast.includes.length > 0) {
+      ast.includes.forEach(inc => checkPath(inc.path, inc.range.start.offset, inc.range.end.offset));
+    } else {
+      const includeRegex = /<#include\s+['"]([^'"<>]+)['"]/g;
+      let match: RegExpExecArray | null;
+      while ((match = includeRegex.exec(content)) !== null) {
+        checkPath(match[1], match.index, match.index + match[0].length);
+      }
+    }
   }
 
   private generatePerformanceMetrics(): PerformanceMetrics {


### PR DESCRIPTION
## Summary
- flag undefined variables and functions during semantic analysis
- report basic syntax errors like unclosed interpolations
- extend integration tests for missing imports, undefined variables, and syntax errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c81312de7083289524cfe77146eb83