### PR TITLE
Run FreeMarker diagnostics asynchronously

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,48 +10,52 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(diagnosticCollection);
 
   if (vscode.window.activeTextEditor) {
-    refreshDiagnostics(vscode.window.activeTextEditor.document);
+    void refreshDiagnostics(vscode.window.activeTextEditor.document);
   }
 
   context.subscriptions.push(
-    vscode.workspace.onDidOpenTextDocument(refreshDiagnostics),
-    vscode.workspace.onDidChangeTextDocument(e => refreshDiagnostics(e.document)),
+    vscode.workspace.onDidOpenTextDocument(document => void refreshDiagnostics(document)),
+    vscode.workspace.onDidChangeTextDocument(e => void refreshDiagnostics(e.document)),
     vscode.workspace.onDidCloseTextDocument(doc => diagnosticCollection.delete(doc.uri))
   );
 }
 
-function refreshDiagnostics(document: vscode.TextDocument): void {
+async function refreshDiagnostics(document: vscode.TextDocument): Promise<void> {
   if (document.languageId !== 'ftl') {
     return;
   }
 
-  const result = analyzer.analyze(document.getText());
-  const diagnostics = result.diagnostics.map(d => {
-    const start = new vscode.Position(d.range.start.line - 1, d.range.start.character - 1);
-    const end = new vscode.Position(d.range.end.line - 1, d.range.end.character - 1);
-    const range = new vscode.Range(start, end);
+  try {
+    const result = await analyzer.analyze(document.getText(), document.uri.fsPath);
+    const diagnostics = result.diagnostics.map(d => {
+      const start = new vscode.Position(d.range.start.line - 1, d.range.start.character - 1);
+      const end = new vscode.Position(d.range.end.line - 1, d.range.end.character - 1);
+      const range = new vscode.Range(start, end);
 
-    let severity: vscode.DiagnosticSeverity;
-    switch (d.severity) {
-      case 'warning':
-        severity = vscode.DiagnosticSeverity.Warning;
-        break;
-      case 'info':
-        severity = vscode.DiagnosticSeverity.Information;
-        break;
-      default:
-        severity = vscode.DiagnosticSeverity.Error;
-    }
+      let severity: vscode.DiagnosticSeverity;
+      switch (d.severity) {
+        case 'warning':
+          severity = vscode.DiagnosticSeverity.Warning;
+          break;
+        case 'info':
+          severity = vscode.DiagnosticSeverity.Information;
+          break;
+        default:
+          severity = vscode.DiagnosticSeverity.Error;
+      }
 
-    const diag = new vscode.Diagnostic(range, d.message, severity);
-    if (d.code) {
-      diag.code = d.code;
-    }
-    diag.source = d.source;
-    return diag;
-  });
+      const diag = new vscode.Diagnostic(range, d.message, severity);
+      if (d.code) {
+        diag.code = d.code;
+      }
+      diag.source = d.source;
+      return diag;
+    });
 
-  diagnosticCollection.set(document.uri, diagnostics);
+    diagnosticCollection.set(document.uri, diagnostics);
+  } catch (error) {
+    console.error('Failed to analyze FreeMarker template', error);
+  }
 }
 
 export function deactivate(): void {

--- a/src/static-analyzer/__tests__/integration.test.ts
+++ b/src/static-analyzer/__tests__/integration.test.ts
@@ -9,7 +9,7 @@ describe('FreeMarker Static Analyzer Integration', () => {
   });
 
   describe('End-to-end analysis', () => {
-    test('should analyze basic FreeMarker template', () => {
+    test('should analyze basic FreeMarker template', async () => {
       const template = `
         <#assign title = "Test"/>
         <#if users??>
@@ -19,7 +19,7 @@ describe('FreeMarker Static Analyzer Integration', () => {
         </#if>
       `;
 
-      const result = analyzer.analyze(template);
+      const result = await analyzer.analyze(template);
 
       expect(result.ast).toBeDefined();
       expect(result.performance).toBeDefined();
@@ -27,7 +27,7 @@ describe('FreeMarker Static Analyzer Integration', () => {
       expect(result.diagnostics).toBeDefined();
     });
 
-    test('should not crash on complex template', () => {
+    test('should not crash on complex template', async () => {
       const template = `
         <#macro card user>
           <div>\${user.name}</div>
@@ -38,15 +38,15 @@ describe('FreeMarker Static Analyzer Integration', () => {
         <@card user=currentUser/>
       `;
 
-      expect(() => analyzer.analyze(template)).not.toThrow();
+      await expect(analyzer.analyze(template)).resolves.toBeDefined();
     });
 
-    test('should handle incremental analysis', () => {
+    test('should handle incremental analysis', async () => {
       const template1 = '<#assign x = 1/>';
       const template2 = '<#assign x = 1/><#assign y = 2/>';
 
-      const result1 = analyzer.analyze(template1);
-      const result2 = analyzer.analyzeIncremental(template2, [], result1);
+      const result1 = await analyzer.analyze(template1);
+      const result2 = await analyzer.analyzeIncremental(template2, [], result1);
 
       expect(result2).toBeDefined();
       expect(result2.semanticInfo).toBeDefined();
@@ -54,13 +54,13 @@ describe('FreeMarker Static Analyzer Integration', () => {
   });
 
   describe('Basic robustness', () => {
-    test('should handle simple malformed template', () => {
+    test('should handle simple malformed template', async () => {
       const template = '<#assign x = "test"/>${x}';
-      expect(() => analyzer.analyze(template)).not.toThrow();
+      await expect(analyzer.analyze(template)).resolves.toBeDefined();
     });
 
-    test('should handle empty template', () => {
-      expect(() => analyzer.analyze('')).not.toThrow();
+    test('should handle empty template', async () => {
+      await expect(analyzer.analyze('')).resolves.toBeDefined();
     });
   });
 });

--- a/src/static-analyzer/import-resolver.ts
+++ b/src/static-analyzer/import-resolver.ts
@@ -204,7 +204,7 @@ export class ImportResolver {
     };
 
     try {
-      const result = this.analyzer.analyze(templateContent, uri);
+      const result = await this.analyzer.analyze(templateContent, uri);
       node.ast = result.ast;
       
       // Add any analysis errors

--- a/src/static-analyzer/index.ts
+++ b/src/static-analyzer/index.ts
@@ -88,9 +88,9 @@ export class FreeMarkerStaticAnalyzer {
     this.parser = new FreeMarkerParser([]);
   }
 
-  public analyze(template: string, _filePath?: string): AnalysisResult {
+  public async analyze(template: string, _filePath?: string): Promise<AnalysisResult> {
     this.profiler.start();
-    
+
     try {
       // Tokenize
       this.profiler.startPhase('lexing');
@@ -141,11 +141,11 @@ export class FreeMarkerStaticAnalyzer {
     }
   }
 
-  public analyzeIncremental(
+  public async analyzeIncremental(
     template: string,
     _changes: any[],
     _previousResult: AnalysisResult
-  ): AnalysisResult {
+  ): Promise<AnalysisResult> {
     // For now, perform full analysis
     // In the future, this could be optimized for incremental updates
     return this.analyze(template);


### PR DESCRIPTION
## Summary
- convert `FreeMarkerStaticAnalyzer.analyze` and incremental analysis to async and await them in the import resolver
- update the VS Code diagnostic refresh to await asynchronous analysis and handle errors
- adapt integration tests to the asynchronous analyzer API

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c865df05ac832882eb0e7d4abe81fd